### PR TITLE
fix: bounds-check payload before accessing dim level in parse_lastdata

### DIFF
--- a/pyplejd/interface/plejd_light.py
+++ b/pyplejd/interface/plejd_light.py
@@ -1,6 +1,10 @@
+import logging
+
 from .plejd_device import PlejdOutput, PlejdTraits, PlejdDeviceType
 from ..ble import LastData, MiniPkg, LightLevel
 from ..ble.debug import rec_log
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class PlejdLight(PlejdOutput):
@@ -39,7 +43,13 @@ class PlejdLight(PlejdOutput):
             ):
                 state["state"] = bool(data.payload[0])
                 if state["state"]:
-                    state["dim"] = data.payload[2]
+                    if len(data.payload) > 2:
+                        state["dim"] = data.payload[2]
+                    else:
+                        _LOGGER.debug(
+                            "plejd short payload for device %s command 0x%04x: %s",
+                            self.address, data.command, data.hex
+                        )
             case LastData.CMD_OUTPUT_SET:
                 for p in data.minipkgs:
                     if p.type == MiniPkg.TPE_WHITEBALANCE:

--- a/pyplejd/interface/plejd_light.py
+++ b/pyplejd/interface/plejd_light.py
@@ -1,10 +1,6 @@
-import logging
-
 from .plejd_device import PlejdOutput, PlejdTraits, PlejdDeviceType
 from ..ble import LastData, MiniPkg, LightLevel
 from ..ble.debug import rec_log
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class PlejdLight(PlejdOutput):
@@ -46,10 +42,7 @@ class PlejdLight(PlejdOutput):
                     if len(data.payload) > 2:
                         state["dim"] = data.payload[2]
                     else:
-                        _LOGGER.debug(
-                            "plejd short payload for device %s command 0x%04x: %s",
-                            self.address, data.command, data.hex
-                        )
+                        rec_log(f"Short payload for command 0x{data.command:04x}: {data.hex}", self.address)
             case LastData.CMD_OUTPUT_SET:
                 for p in data.minipkgs:
                     if p.type == MiniPkg.TPE_WHITEBALANCE:


### PR DESCRIPTION
## Summary

`parse_lastdata()` accesses `data.payload[2]` without a bounds check in the `CMD_GROUP_OUTPUT_STATE_AND_LEVEL` / `CMD_OUTPUT_STATE_AND_LEVEL` branch. Some devices send this command with fewer than 3 payload bytes, causing repeated unhandled `IndexError` exceptions.

Reported in thomasloven/hass-plejd#148. In that case the trigger was a **REL-02 relay** (hardware ID 18, `RELLightRelay` load type) sending the following payload repeatedly:

```
command 0x00c8: 21010200c801
```

A relay has no meaningful dim level, so it appears to report on/off state via a STATE_AND_LEVEL command but omit the level byte.

## Changes

- Add a `len(data.payload) > 2` guard before accessing `data.payload[2]`
- Log at `DEBUG` level when the short-payload case is hit, to aid future diagnosis
- Add `logging` import

## Before

```python
if state["state"]:
    state["dim"] = data.payload[2]
```

## After

```python
if state["state"]:
    if len(data.payload) > 2:
        state["dim"] = data.payload[2]
    else:
        _LOGGER.debug(
            "plejd short payload for device %s command 0x%04x: %s",
            self.address, data.command, data.hex
        )
```