### PR TITLE
Fix BLE ping flood caused by inverted first-seen detection

### DIFF
--- a/pyplejd/ble/__init__.py
+++ b/pyplejd/ble/__init__.py
@@ -39,7 +39,7 @@ class MeshDevice:
         self.last_seen = datetime.now()
         self.rssi = max(self.rssi, rssi)
 
-        return first_seen
+        return first_seen is None
 
     def update():
         pass

--- a/pyplejd/ble/__init__.py
+++ b/pyplejd/ble/__init__.py
@@ -32,14 +32,14 @@ class MeshDevice:
 
     def see(self, rssi, bleDevice: BLEDevice) -> bool:
         # Returns true if first seen
-        if (first_seen := self.rssi) is None:
+        if (first_seen := (self.rssi is None)):
             self.bleDevice = bleDevice
             self.rssi = rssi
 
         self.last_seen = datetime.now()
         self.rssi = max(self.rssi, rssi)
 
-        return first_seen is None
+        return first_seen
 
     def update():
         pass


### PR DESCRIPTION
I recently upgraded my Plejd integration and noticed that my lights were either unresponsive or taking 10+ seconds to react to commands after a while. I poked around a bit and the logs showed a familiar ping storm - the same issue I fixed in #7 from just over a year ago!

The refactor in 713ab69 introduced a regression in `MeshDevice.see()` where `return first_seen` returns the old `self.rssi` value instead of a boolean - so it's falsy for new devices and truthy for already-seen ones. Exactly inverted, meaning every discovery event for a known device triggers a ping + full state poll, flooding the radio.

`see()` now correctly returns `True` for first-seen devices and `False` for subsequent discoveries.

I'm trying this change at home and it looks good, although I still have to wait until tomorrow to really see if it's working since it takes a while for the ping storm to get really bad.