### PR TITLE
Make device title optional. Should fix latest the latest API changes.

### DIFF
--- a/pyplejd/cloud/site_details.py
+++ b/pyplejd/cloud/site_details.py
@@ -76,7 +76,7 @@ class Scene(PlejdObject):
 class Device(PlejdObject):
     deviceId: str
     siteId: str
-    title: str
+    title: Optional[str] = ""
     traits: int
     hiddenFromRoomList: bool = False
     roomId: Optional[str] = ""


### PR DESCRIPTION
There was a change in Plejd API that causes title to be missing in some devices. Making it optional fixes the integration in Home Assistant at this moment at least in my setup. 