### PR TITLE
Fix for crash when device is missing title

### DIFF
--- a/pyplejd/cloud/site_details.py
+++ b/pyplejd/cloud/site_details.py
@@ -36,7 +36,7 @@ class User(PlejdObject):
 
 class Site(PlejdObject):
     # installers: list[str] = []
-    title: str
+    title: str = ""
     siteId: str
     version: int
     # plejdMesh: Pointer # Pointer to SiteData.plejdMesh
@@ -60,13 +60,13 @@ class PlejdMesh(PlejdObject):
 class Room(PlejdObject):
     siteId: str
     roomId: str
-    title: str
+    title: str = ""
     category: str
     # imageHash: int
 
 
 class Scene(PlejdObject):
-    title: str
+    title: str = ""
     sceneId: str
     siteId: str
     hiddenFromSceneList: bool = False
@@ -76,7 +76,7 @@ class Scene(PlejdObject):
 class Device(PlejdObject):
     deviceId: str
     siteId: str
-    title: str
+    title: str = ""
     traits: int
     hiddenFromRoomList: bool = False
     roomId: Optional[str] = ""


### PR DESCRIPTION
After rearranging some devices between rooms in the Plejd app, the integration failed to start with a Pydantic validation error:

```
pydantic_core.ValidationError: 1 validation error for SiteDetails
devices.2.title
  Field required [type=missing, ...]
```

The device in question (a WPH-01) does have a name in the Plejd app, so the cloud API seems to occasionally return devices without the title field. This takes down the entire integration.

Suggesting to make `title` optional with a default on the Device model (and the other models using it) to prevent this from happening.